### PR TITLE
Remove redundant `memset()` calls in `msdos_init()`

### DIFF
--- a/msdos.cpp
+++ b/msdos.cpp
@@ -19325,7 +19325,6 @@ void msdos_syscall(unsigned num)
 int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 {
 	// init file handler
-	memset(file_handler, 0, sizeof(file_handler));
 	msdos_file_handler_open(0, "STDIN", _isatty(0), 0, 0x80d3, 0);
 	msdos_file_handler_open(1, "STDOUT", _isatty(1), 1, 0x80d3, 0);
 	msdos_file_handler_open(2, "STDERR", _isatty(2), 1, 0x80d3, 0);
@@ -19347,7 +19346,6 @@ int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 	_dup2(4, DUP_STDPRN);
 	
 	// init mouse
-	memset(&mouse, 0, sizeof(mouse));
 	mouse.enabled = true;	// from DOSBox
 	mouse.hidden = 1;	// hidden in default ???
 	mouse.old_hidden = 1;	// from DOSBox
@@ -19361,14 +19359,8 @@ int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 	msdos_xms_init();
 #endif
 	
-	// init process
-	memset(process, 0, sizeof(process));
-	
 	// init dtainfo
 	msdos_dta_info_init();
-	
-	// init memory
-	memset(mem, 0, sizeof(mem));
 	
 	// bios data area
 	HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);


### PR DESCRIPTION
`msdos_init()` is only called a single time in `main()`, and all of these variables have static storage duration and are automatically initialized to 0. Removing these calls avoids touching quite a lot of memory at startup (32.8 MiB in `HAS_I386` builds). Not much in isolation, but it quickly adds up if you've got a build process that simultaneously spawns one MS-DOS Player process for each CPU core, multiple times a second.

Here are some timing comparisions from my WIP rewrite of the [ReC98](https://github.com/nmlgc/ReC98) build process. This is one full rebuild of the entire codebase on a 6-year-old i5 CPU, using both a generic MS-DOS Player Release build and a profile-optimized one for this specific workload:

|             | Generic build | PGO build |
| ----------- | ------------- | --------- |
| Current    | 32.707s       | 28.286s   |
| Removed `memset` | 30.433s       | 25.781s   |
