### PR TITLE
Disable VT mode if stdout is redirected

### DIFF
--- a/msdos.cpp
+++ b/msdos.cpp
@@ -3816,8 +3816,11 @@ int main(int argc, char *argv[], char *envp[])
 
 	if(use_vt) {
 		DWORD mode;
-		GetConsoleMode(hStdout, &mode);
-		SetConsoleMode(hStdout, mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+		if(GetConsoleMode(hStdout, &mode)) {
+			SetConsoleMode(hStdout, mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+		} else {
+			use_vt = false;
+		}
 	}
 	
 	SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);


### PR DESCRIPTION
`read_cursor_pos()` sends `"\x1b[6n"` to stdout and then expects to read the cursor position from stdin. This can never work if stdout is not a console, and causes MS-DOS Player to hang in an infinite loop in that case.

Since `use_vt` is set based on the Windows version and the `-vt` flag merely toggles this default, we also get different behavior depending on the OS: On Windows ≥10, `msdos prog >NUL` would hang and `msdos prog -vt >NUL` would run, but it's the other way around on earlier Windows versions.