### PR TITLE
Device drivers support

### DIFF
--- a/msdos.cpp
+++ b/msdos.cpp
@@ -5984,7 +5984,7 @@ int msdos_open(const char *path, int oflag)
 		disposition = CREATE_ALWAYS;
 		break;
 	}
-	
+
 	HANDLE h = CreateFileA(path, GENERIC_READ | FILE_WRITE_ATTRIBUTES,
 		FILE_SHARE_READ | FILE_SHARE_WRITE, &sa, disposition,
 		FILE_ATTRIBUTE_NORMAL, NULL);
@@ -6030,6 +6030,9 @@ int msdos_open_device(const char *path, int oflag, int *sio_port, int *lpt_port)
 		msdos_set_comm_params(*sio_port, path);
 	} else if((*lpt_port = msdos_is_prn_path(path)) != 0) {
 		fd = msdos_open("NUL", oflag);
+	} else if(dos_get_device(path).dw) {
+		// Create a temporary file to get a valid file descriptor for the device
+		fd = _open(path, _O_CREAT | _O_TEMPORARY, _S_IREAD | _S_IWRITE);
 	} else if(msdos_is_device_path(path)) {
 		fd = msdos_open("NUL", oflag);
 //	} else if(oflag & _O_CREAT) {
@@ -6071,7 +6074,7 @@ UINT16 msdos_device_info(const char *path)
 		}
 		// Search in the device_t linked list
 		device = dos_get_device(path);
-		if(device.dw != 0){
+		if(device.dw){
 			device_header = (device_t*)FAR_POINTER(device);
 			return(device_header->attributes);
 		}
@@ -6086,7 +6089,7 @@ void msdos_file_handler_open(int fd, const char *path, int atty, int mode, UINT1
 	static int id = 0;
 	char full[MAX_PATH], *name;
 	
-	if(GetFullPathNameA(path, MAX_PATH, full, &name) != 0) {
+	if(GetFullPathNameA(path, MAX_PATH, full, &name) != 0 && !(info & DOS_DEVATTR_IOCTL)) {
 		strcpy(file_handler[fd].path, full);
 	} else {
 		strcpy(file_handler[fd].path, path);
@@ -14238,6 +14241,7 @@ inline void msdos_int_21h_44h()
 	process_t *process;
 	int fd = 0, drv = 0;
 	CPINFO info;
+	PAIR32 device;
 	
 	switch(CPU_AL) {
 	case 0x00:
@@ -14378,9 +14382,28 @@ inline void msdos_int_21h_44h()
 		}
 		break;
 	case 0x03: // Write To Character Device Control Channel
-//		CPU_AX = 0x05;
-//		CPU_SET_C_FLAG(1);
-		CPU_AX = 0x00; // success
+		// If installed device, send driver request
+		device = dos_get_device(file_handler[fd].path);
+		if(device.dw && (file_handler[fd].info & DOS_DEVATTR_IOCTL)){
+			PAIR32 buffer;
+			WORD length = CPU_CX;
+			buffer.w.h = CPU_DS;
+			buffer.w.l = CPU_DX;
+			WORD status = DosDriverRequest(device, buffer, &length, DOS_DEVCMD_IOCTL_WRITE);
+			if(status & DOS_DEVSTAT_ERROR){
+				CPU_AX = status & 0xff;
+				CPU_SET_C_FLAG(1);
+			}
+			else{
+				CPU_AX = length;
+			}
+		}
+		else{
+			// If dummy device, return success
+//			CPU_AX = 0x05;
+//			CPU_SET_C_FLAG(1);
+			CPU_AX = 0x00; // success
+		}
 		break;
 	case 0x04: // Read From Block Device Control Channel
 	case 0x05: // Write To Block Device Control Channel
@@ -26097,11 +26120,18 @@ void vdd_init_table(PVDD_FUNC_TABLE ptr)
 int load_config_sys()
 {
 	FILE *fp;
-	char line[1024];
+	char line[1024], old_path[_MAX_PATH], my_path[_MAX_PATH], drive[_MAX_DRIVE], dir[_MAX_DIR];
 	char *path, *args, *c;
 	int devices_added = 0;
 	bool quote = 0;
 	DWORD result;
+
+	// Get path to this executable
+	GetModuleFileNameA(NULL, my_path, sizeof(my_path));
+	_splitpath_s(my_path, drive, sizeof(drive), dir, sizeof(dir), NULL, 0, NULL, 0);
+	sprintf_s(my_path, sizeof(my_path), "%s%s", drive, dir);
+	getcwd(old_path, _MAX_PATH);
+	chdir(my_path);
 
 	// Open config.sys (the file must be in the same directory as msdos.exe)
 	fp = fopen("config.sys", "r");
@@ -26151,6 +26181,10 @@ int load_config_sys()
 	}
 	
 	fclose(fp);
+
+	// Set the previous path
+	chdir(old_path);
+
 	return devices_added;
 }
 
@@ -26167,7 +26201,7 @@ DWORD DosLoadDriver(LPCSTR DriverFile)
     DWORD DriversLoaded = 0;
     DOS_INIT_REQUEST Request;
 	sda_t *sda = (sda_t *)(mem + SDA_TOP);
-	mcb_t *mcb_driver;
+	mcb_t *mcb_driver, *mcb_driver_config;
 	const char *tmp;
  
     /* Open a handle to the driver file */
@@ -26187,29 +26221,38 @@ DWORD DosLoadDriver(LPCSTR DriverFile)
     /* Get the file size */
     FileSize = GetFileSize(FileHandle, NULL);
  
-    /* Allocate DOS memory for the driver */
-	if((seg = msdos_mem_alloc(first_mcb, (FileSize >> 4) + 1)) == -1)
+    /* Allocate DOS memory for the driver. Add one paragraph for driver config MCB and one more for rounding paragraph. */
+	if((seg = msdos_mem_alloc(first_mcb, (FileSize >> 4) + 2)) == -1)
     {
         Result = sda->extended_error_code;
         goto Cleanup;
     }
+
+	/* Set the MCB so MEM.exe will show the driver */
 	mcb_driver = (mcb_t *)(mem + ((seg - 1) << 4));
-	mcb_driver->psp = seg; //mcb_driver->psp = PSP_SYSTEM;
+	mcb_driver->psp = PSP_SYSTEM;
+	mcb_driver->prog_name[0] = 'S';
+	mcb_driver->prog_name[1] = 'D';
+	mcb_driver->prog_name[2] = '\0';
+
+	/* Add Driver Config subsequent MCB */
+	mcb_driver_config = msdos_mcb_create(seg, 'D', seg + 1, mcb_driver->paragraphs - 1);
 	tmp = msdos_file_name(DriverFile);
 	for(int i = 0; i < 8; i++) {
 		if(tmp[i] == '.') {
-			mcb_driver->prog_name[i] = '\0';
+			mcb_driver_config->prog_name[i] = '\0';
 			break;
 		} else if(i < 7 && msdos_lead_byte_check(tmp[i])) {
-			mcb_driver->prog_name[i] = tmp[i];
+			mcb_driver_config->prog_name[i] = tmp[i];
 			i++;
-			mcb_driver->prog_name[i] = tmp[i];
+			mcb_driver_config->prog_name[i] = tmp[i];
 		} else if(tmp[i] >= 'a' && tmp[i] <= 'z') {
-			mcb_driver->prog_name[i] = tmp[i] - 'a' + 'A';
+			mcb_driver_config->prog_name[i] = tmp[i] - 'a' + 'A';
 		} else {
-			mcb_driver->prog_name[i] = tmp[i];
+			mcb_driver_config->prog_name[i] = tmp[i];
 		}
 	}
+	seg++;
  
     /* Create a mapping object for the file */
     FileMapping = CreateFileMappingA(FileHandle,
@@ -26241,36 +26284,38 @@ DWORD DosLoadDriver(LPCSTR DriverFile)
     /* Loop through all the drivers in this file */
     while (TRUE)
     {
-        if (!(DriverHeader->attributes & DOS_DEVATTR_CHARACTER))
+        if (DriverHeader->attributes & DOS_DEVATTR_CHARACTER)
         {
-            fprintf(stderr, "Error loading driver at %04X:%04X: "
-                    "Block device drivers are not supported.\n",
-                    Driver.w.h,
-                    Driver.w.l);
-            goto Next;
-        }
- 
-        /* Send the driver an init request */
-        memset(&Request, 0, sizeof(Request));
-        Request.Header.RequestLength = sizeof(DOS_INIT_REQUEST);
-        Request.Header.CommandCode = DOS_DEVCMD_INIT;
-        DosCallDriver(Driver, &Request.Header);
-		
-        if (Request.Header.Status & DOS_DEVSTAT_ERROR)
-        {
+            /* Send the driver an init request */
+			memset(&Request, 0, sizeof(Request));
+			Request.Header.RequestLength = sizeof(DOS_INIT_REQUEST);
+			Request.Header.CommandCode = DOS_DEVCMD_INIT;
+			DosCallDriver(Driver, &Request.Header);
+
+			/* If init was successful, link the driver block */
+			if (!(Request.Header.Status & DOS_DEVSTAT_ERROR))
+			{
+				DosAddDriver(Driver);
+        		DriversLoaded++;
+			}
+			else
+        	{
             fprintf(stderr, "Error loading driver at %04X:%04X: "
                     "Initialization routine returned error %u.\n",
                     Driver.w.h,
                     Driver.w.l,
                     Request.Header.Status & 0x7F);
-            goto Next;
+        	}
         }
-
-		//fprintf(stderr, "Adding driver %.*s at %04X:%04X\n", MAX_DEVICE_NAME, DriverHeader->dev_name, Driver.w.h, Driver.w.l);
-        DosAddDriver(Driver);
-        DriversLoaded++;
+		else
+		{
+			fprintf(stderr, "Error loading driver at %04X:%04X: "
+				"Block device drivers are not supported.\n",
+				Driver.w.h,
+				Driver.w.l);
+		}
  
-Next:
+		/* Check if this .sys file has more drivers to load */
         if (DriverHeader->next_driver.w.l == 0xFFFF) break;
         Driver = DriverHeader->next_driver;
         DriverHeader = (device_t*)FAR_POINTER(Driver);
@@ -26293,19 +26338,6 @@ Cleanup:
     if (FileHandle != INVALID_HANDLE_VALUE) CloseHandle(FileHandle);
  
     return Result;
-}
-
-// From ReactOS
-static inline WORD DosDriverGenericRequest(PAIR32 Driver, BYTE CommandCode)
-{
-DOS_REQUEST_HEADER Request;
-
-Request.RequestLength = sizeof(DOS_REQUEST_HEADER);
-Request.CommandCode = CommandCode;
-
-DosCallDriver(Driver, &Request);
-
-return Request.Status;
 }
 
 // From ReactOS
@@ -26340,6 +26372,21 @@ static VOID DosAddDriver(PAIR32 Driver)
 }
 
 // From ReactOS
+static inline WORD DosDriverRequest(PAIR32 Driver, PAIR32 Buffer, PWORD Length, BYTE CommandCode)
+{
+	DOS_RW_REQUEST Request;
+	Request.Header.RequestLength = sizeof(DOS_RW_REQUEST);
+	Request.Header.CommandCode = CommandCode;
+	Request.BufferPointer = Buffer;
+	Request.Length = *Length;
+
+	DosCallDriver(Driver, &Request.Header);
+
+	*Length = Request.Length;
+	return Request.Header.Status;
+}
+
+// From ReactOS
 static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request)
 {
     device_t *DriverBlock = (device_t*)FAR_POINTER(Driver);
@@ -26357,13 +26404,13 @@ static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request)
 
     // Copy the request structure to ES:BX 
     memmove(&sda->Request, Request, Request->RequestLength);
- 
+
 	// Set ES:BX to the location of the request 
 	CPU_LOAD_SREG(CPU_ES_INDEX, SDA_TOP >> 4);
 	CPU_BX = offsetof(sda_t, Request);
 
     // Call the strategy routine, and then the interrupt routine
-    RunCallback16(Driver.w.h, DriverBlock->strategy);
+	RunCallback16(Driver.w.h, DriverBlock->strategy);
     RunCallback16(Driver.w.h, DriverBlock->interrupt);
  
     // Get the request structure from ES:BX
@@ -26402,6 +26449,19 @@ PAIR32 dos_get_device(const char* name)
 	dos_info_t *dos_info = (dos_info_t *)(mem + DOS_INFO_TOP);
 	PAIR32 Driver = dos_info->nul_device.next_driver;
 	device_t *DriverHeader;
+
+	// Skip dummy devices
+	if(_stricmp(name, "CLOCK$"  ) == 0 ||
+		_stricmp(name, "CONFIG$" ) == 0 ||
+		_stricmp(name, "EMMXXXX0") == 0 ||
+//		stricmp(name, "SCSIMGR$") == 0 ||
+		_stricmp(name, "$IBMAFNT") == 0 ||
+		_stricmp(name, "$IBMADSP") == 0 ||
+		_stricmp(name, "$IBMAIAS") == 0 ||
+		_stricmp(name, "FP$ATOK6") == 0) {
+		Driver.dw = 0;
+		return(Driver);
+	}
 
 	if(strlen(name) <= MAX_DEVICE_NAME){
 		// Search in the device_t linked list

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -456,6 +456,8 @@ bool glyph_char = false;
 bool is_dbcs_cp = false;
 bool hide_cursor = false;
 
+char devices_to_load[MAX_PATH];
+
 #define UPDATE_OPS 16384
 #define REQUEST_HARDWRE_UPDATE() { \
 	update_ops = UPDATE_OPS - 1; \
@@ -3826,6 +3828,9 @@ int main(int argc, char *argv[], char *envp[])
 		} else if(_strnicmp(argv[i], "-a", 2) == 0) {
 			ansi_sys = false;
 			arg_offset++;
+		} else if(_strnicmp(argv[i], "-ld", 3) == 0) {
+			strcpy_s(devices_to_load, MAX_PATH, &argv[i][3]);
+			arg_offset++;
 		} else if(_strnicmp(argv[i], "-l", 2) == 0) {
 			box_line = true;
 			arg_offset++;
@@ -3856,8 +3861,8 @@ int main(int argc, char *argv[], char *envp[])
 		fprintf(stderr,
 			"Usage:\n\n"
 			"MSDOS [-b] [-c[(new exec file)] [-p[P]]] [-d] [-e] [-fN] [-i] [-m] [-n[L[,C]]]\n"
-			"      [-s[P1[,P2[,P3[,P4]]]]] [-sd] [-sc] [-vX.XX] [-wX.XX] [-x] [-a] [-l] [-vt] [-g] [-h]\n"
-			"      (command) [options]\n"
+			"      [-s[P1[,P2[,P3[,P4]]]]] [-sd] [-sc] [-vX.XX] [-wX.XX] [-x] [-a]\n"
+			"      [-ld[(drivers)]] [-l] [-vt] [-g] [-h] (command) [options]\n"
 			"\n"
 			"\t-b\tstay busy during keyboard polling\n"
 #ifdef _WIN64
@@ -3885,6 +3890,7 @@ int main(int argc, char *argv[], char *envp[])
 			"\t-x\tenable LIM EMS\n"
 #endif
 			"\t-a\tdisable ANSI.SYS\n"
+			"\t-ld\tload device drivers\n"
 			"\t-l\tdraw box lines with ank characters\n"
 			"\t-vt\ttoggle vt mode, default is on for win10 and above\n"
 			"\t-g\tuse cp437 glyphs for code points 0-31, always enabled in cp437\n"
@@ -22228,8 +22234,8 @@ int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 	// NLS stuff
 	msdos_nls_tables_init();
 
-	// Parse config.sys to load VDD device drivers
-	load_config_sys();
+	// Load device drivers specified with -ld
+	load_devices(devices_to_load);
 	
 	// execute command
 	try {
@@ -26202,79 +26208,32 @@ void vdd_init_table(PVDD_FUNC_TABLE ptr)
 }
 #endif
 
-// Load device drivers from config.sys
-int load_config_sys()
+// Load device drivers from a list delimited by ";"
+void load_devices(char *device_list)
 {
-	FILE *fp;
-	char line[1024], old_path[_MAX_PATH], my_path[_MAX_PATH], drive[_MAX_DRIVE], dir[_MAX_DIR];
-	char *path, *args, *c;
-	int devices_added = 0;
-	bool quote = 0;
-	DWORD result;
+	char *token;
+	DWORD dwAttrib;
 
-	// Get path to this executable
-	GetModuleFileNameA(NULL, my_path, sizeof(my_path));
-	_splitpath_s(my_path, drive, sizeof(drive), dir, sizeof(dir), NULL, 0, NULL, 0);
-	sprintf_s(my_path, sizeof(my_path), "%s%s", drive, dir);
-	getcwd(old_path, _MAX_PATH);
-	chdir(my_path);
-
-	// Open config.sys (the file must be in the same directory as msdos.exe)
-	fp = fopen("config.sys", "r");
-	if(fp == NULL){
-		return 0;
-	}
-	
-	// Check each line of the file
-	while(fgets(line, sizeof(line), fp) != NULL)
-	{
-		// Only "DEVICE" is implemented
-		if(my_strstr(line, "DEVICE=") != NULL)
-		{
-			path = line + sizeof("DEVICE=") - 1;
-			args = 0;
-			// Evaluate each char of the path until end of line
-			for(c = path; c < (line + sizeof(line)); c++)
-			{
-				// Terminate line if non-readable character
-				if(*c < ' ')
+	// Parse device_list
+	if(device_list && device_list[0] != '\0'){
+		token = my_strtok(device_list, ";");
+		while(token) {
+			// Check if valid file path		
+			dwAttrib = GetFileAttributesA(token);
+			if((dwAttrib != INVALID_FILE_ATTRIBUTES && 
+				!(dwAttrib & FILE_ATTRIBUTE_DIRECTORY))){
+				// Handle .sys files only
+				if(check_file_extension(token, ".SYS"))
 				{
-					*c = '\0';
-					if(!args) {args = c;}
-					break;
-				}
-				// Find the end of path and start of arguments
-				if(!args)
-				{
-					// Check if inside of quotation marks
-					if(*c == '\"') {quote = !quote;}
-					// If not inside quotation marks, we found the end of the path
-					if(!quote && (*c == ' '))
-					{
-						*c = '\0';
-						args = c + 1;
-					}
+					DosLoadDriver(token);
 				}
 			}
-			// Handle .sys files, no args
-			if(check_file_extension(path, ".SYS"))
-			{
-				if(result = DosLoadDriver(path) == ERROR_SUCCESS){
-					devices_added++;
-				}
-			}
+			token = my_strtok(NULL, ";");
 		}
 	}
-	
-	fclose(fp);
-
-	// Set the previous path
-	chdir(old_path);
-
-	return devices_added;
 }
 
-// From ReactOS
+// Load a .sys file into memory and install it
 DWORD DosLoadDriver(LPCSTR DriverFile)
 {
     DWORD Result = ERROR_SUCCESS;
@@ -26284,7 +26243,6 @@ DWORD DosLoadDriver(LPCSTR DriverFile)
     device_t *DriverHeader;
     WORD seg = 0;
     DWORD FileSize;
-    DWORD DriversLoaded = 0;
     DOS_INIT_REQUEST Request;
 	sda_t *sda = (sda_t *)(mem + SDA_TOP);
 	mcb_t *mcb_driver, *mcb_driver_config;
@@ -26382,7 +26340,6 @@ DWORD DosLoadDriver(LPCSTR DriverFile)
 			if (!(Request.Header.Status & DOS_DEVSTAT_ERROR))
 			{
 				DosAddDriver(Driver);
-        		DriversLoaded++;
 			}
 			else
         	{
@@ -26426,7 +26383,7 @@ Cleanup:
     return Result;
 }
 
-// From ReactOS
+// Add a driver to the device_t linked list
 static VOID DosAddDriver(PAIR32 Driver)
 {
 	dos_info_t *dos_info = (dos_info_t *)(mem + DOS_INFO_TOP);
@@ -26441,23 +26398,9 @@ static VOID DosAddDriver(PAIR32 Driver)
     /* Add the new driver to the list */
     LastDriver->next_driver = Driver;
     LastDriver = (device_t *)FAR_POINTER(Driver);
- 
-    if (LastDriver->attributes & 0x0008)	// DOS_DEVATTR_CLOCK
-    {
-        /* Update the active CLOCK driver */
-        dos_info->clock_device = Driver;
-    }
- 
-    if (LastDriver->attributes
-        & (0x0001 | 0x0002 | 0x0010))	// DOS_DEVATTR_STDIN | DOS_DEVATTR_STDOUT | DOS_DEVATTR_CON
-    {
-        /* Update the active CON driver */
-        dos_info->con_device = Driver;
-    }
-	
 }
 
-// From ReactOS
+// Create a request structure and call the driver
 static inline WORD DosDriverRequest(PAIR32 Driver, PAIR32 Buffer, PWORD Length, BYTE CommandCode)
 {
 	DOS_RW_REQUEST Request;
@@ -26472,8 +26415,8 @@ static inline WORD DosDriverRequest(PAIR32 Driver, PAIR32 Buffer, PWORD Length, 
 	return Request.Header.Status;
 }
 
-// From ReactOS
-static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request)
+// Call a device driver using a request structure
+static VOID DosCallDriver(PAIR32 Driver, DOS_REQUEST_HEADER *Request)
 {
     device_t *DriverBlock = (device_t*)FAR_POINTER(Driver);
 	sda_t *sda = (sda_t *)(mem + SDA_TOP);
@@ -26488,7 +26431,7 @@ static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request)
     UINT16 tmp_DS = CPU_DS;
     UINT16 tmp_ES = CPU_ES;
 
-    // Copy the request structure to ES:BX 
+    // Copy the request structure to the sda
     memmove(&sda->Request, Request, Request->RequestLength);
 
 	// Set ES:BX to the location of the request 
@@ -26512,7 +26455,6 @@ static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request)
     CPU_DI = tmp_DI;
     CPU_LOAD_SREG(CPU_DS_INDEX, tmp_DS);
     CPU_LOAD_SREG(CPU_ES_INDEX, tmp_ES);
-
 }
 
 void RunCallback16(UINT16 segment, UINT16 offset)
@@ -26520,6 +26462,7 @@ void RunCallback16(UINT16 segment, UINT16 offset)
 	UINT16 tmp_cs = CPU_CS;
 	UINT32 tmp_eip = CPU_EIP;
 
+	// set instruction pointer
 	CPU_CALL_FAR(segment, offset);
 	// run cpu until routine is done
 	while(!msdos_exit && !(tmp_cs == CPU_CS && tmp_eip == CPU_EIP)) {
@@ -26530,17 +26473,17 @@ void RunCallback16(UINT16 segment, UINT16 offset)
 	}
 }
 
+// Get the PAIR32 address of a device by name
 PAIR32 dos_get_device(const char* name)
 {
 	dos_info_t *dos_info = (dos_info_t *)(mem + DOS_INFO_TOP);
 	PAIR32 Driver = dos_info->nul_device.next_driver;
 	device_t *DriverHeader;
 
-	// Skip dummy devices
+	// Skip dummy devices, return 0
 	if(_stricmp(name, "CLOCK$"  ) == 0 ||
 		_stricmp(name, "CONFIG$" ) == 0 ||
 		_stricmp(name, "EMMXXXX0") == 0 ||
-//		stricmp(name, "SCSIMGR$") == 0 ||
 		_stricmp(name, "$IBMAFNT") == 0 ||
 		_stricmp(name, "$IBMADSP") == 0 ||
 		_stricmp(name, "$IBMAIAS") == 0 ||
@@ -26554,7 +26497,7 @@ PAIR32 dos_get_device(const char* name)
 		while (Driver.w.l != 0xFFFF)
 		{
 			DriverHeader = (device_t*)FAR_POINTER(Driver);
-			// Compare both strings and consider ' ' as string termination
+			// Compare both strings and consider space ' ' as string termination
 			for(int i = 0; i < MAX_DEVICE_NAME; i++){
 				if((i != 0) && (name[i] == '\0' || name[i] == ' ') && (DriverHeader->dev_name[i] == '\0' || DriverHeader->dev_name[i] == ' ')){
 					return(Driver);

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -5621,6 +5621,10 @@ bool msdos_is_device_path(const char *path)
 			   _stricmp(name, "FP$ATOK6") == 0) {
 				return(true);
 			}
+			// Search in the device_t linked list
+			if(dos_get_device(name).dw){
+				return(true);
+			}
 		}
 	}
 	return(false);
@@ -6035,6 +6039,9 @@ int msdos_open_device(const char *path, int oflag, int *sio_port, int *lpt_port)
 
 UINT16 msdos_device_info(const char *path)
 {
+	PAIR32 device;
+	device_t *device_header;
+
 	if(!strnicmp(path, "\\DEV\\", 5)) {
 		path += 5;
 	}
@@ -6058,6 +6065,12 @@ UINT16 msdos_device_info(const char *path)
 		   my_strstr(path, "FP$ATOK6") != NULL) {
 //			return(0xc080);
 			return(0x0080);
+		}
+		// Search in the device_t linked list
+		device = dos_get_device(path);
+		if(device.dw != 0){
+			device_header = (device_t*)FAR_POINTER(device);
+			return(device_header->attributes);
 		}
 		return(0x8084);
 	} else {
@@ -22102,6 +22115,9 @@ int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 	
 	// NLS stuff
 	msdos_nls_tables_init();
+
+	// Parse config.sys to load VDD device drivers
+	load_config_sys();
 	
 	// execute command
 	try {
@@ -26073,3 +26089,334 @@ void vdd_init_table(PVDD_FUNC_TABLE ptr)
 	ptr->VDDDeInstallUserHook = VDDDeInstallUserHook;
 }
 #endif
+
+// Load device drivers from config.sys
+int load_config_sys()
+{
+	FILE *fp;
+	char line[1024];
+	char *path, *args, *c;
+	int devices_added = 0;
+	bool quote = 0;
+	DWORD result;
+
+	// Open config.sys (the file must be in the same directory as msdos.exe)
+	fp = fopen("config.sys", "r");
+	if(fp == NULL){
+		return 0;
+	}
+	
+	// Check each line of the file
+	while(fgets(line, sizeof(line), fp) != NULL)
+	{
+		// Only "DEVICE" is implemented
+		if(my_strstr(line, "DEVICE=") != NULL)
+		{
+			path = line + sizeof("DEVICE=") - 1;
+			args = 0;
+			// Evaluate each char of the path until end of line
+			for(c = path; c < (line + sizeof(line)); c++)
+			{
+				// Terminate line if non-readable character
+				if(*c < ' ')
+				{
+					*c = '\0';
+					if(!args) {args = c;}
+					break;
+				}
+				// Find the end of path and start of arguments
+				if(!args)
+				{
+					// Check if inside of quotation marks
+					if(*c == '\"') {quote = !quote;}
+					// If not inside quotation marks, we found the end of the path
+					if(!quote && (*c == ' '))
+					{
+						*c = '\0';
+						args = c + 1;
+					}
+				}
+			}
+			// Handle .sys files, no args
+			if(check_file_extension(path, ".SYS"))
+			{
+				if(result = DosLoadDriver(path) == ERROR_SUCCESS){
+					devices_added++;
+				}
+			}
+		}
+	}
+	
+	fclose(fp);
+	return devices_added;
+}
+
+// From ReactOS
+DWORD DosLoadDriver(LPCSTR DriverFile)
+{
+    DWORD Result = ERROR_SUCCESS;
+    HANDLE FileHandle = INVALID_HANDLE_VALUE, FileMapping = NULL;
+    LPBYTE Address = NULL;
+    PAIR32 Driver;
+    device_t *DriverHeader;
+    WORD seg = 0;
+    DWORD FileSize;
+    DWORD DriversLoaded = 0;
+    DOS_INIT_REQUEST Request;
+	sda_t *sda = (sda_t *)(mem + SDA_TOP);
+	mcb_t *mcb_driver;
+	const char *tmp;
+ 
+    /* Open a handle to the driver file */
+    FileHandle = CreateFileA(DriverFile,
+                             GENERIC_READ,
+                             FILE_SHARE_READ,
+                             NULL,
+                             OPEN_EXISTING,
+                             FILE_ATTRIBUTE_NORMAL,
+                             NULL);
+    if (FileHandle == INVALID_HANDLE_VALUE)
+    {
+        Result = GetLastError();
+        goto Cleanup;
+    }
+ 
+    /* Get the file size */
+    FileSize = GetFileSize(FileHandle, NULL);
+ 
+    /* Allocate DOS memory for the driver */
+	if((seg = msdos_mem_alloc(first_mcb, (FileSize >> 4) + 1)) == -1)
+    {
+        Result = sda->extended_error_code;
+        goto Cleanup;
+    }
+	mcb_driver = (mcb_t *)(mem + ((seg - 1) << 4));
+	mcb_driver->psp = seg; //mcb_driver->psp = PSP_SYSTEM;
+	tmp = msdos_file_name(DriverFile);
+	for(int i = 0; i < 8; i++) {
+		if(tmp[i] == '.') {
+			mcb_driver->prog_name[i] = '\0';
+			break;
+		} else if(i < 7 && msdos_lead_byte_check(tmp[i])) {
+			mcb_driver->prog_name[i] = tmp[i];
+			i++;
+			mcb_driver->prog_name[i] = tmp[i];
+		} else if(tmp[i] >= 'a' && tmp[i] <= 'z') {
+			mcb_driver->prog_name[i] = tmp[i] - 'a' + 'A';
+		} else {
+			mcb_driver->prog_name[i] = tmp[i];
+		}
+	}
+ 
+    /* Create a mapping object for the file */
+    FileMapping = CreateFileMappingA(FileHandle,
+                                    NULL,
+                                    PAGE_READONLY,
+                                    0,
+                                    0,
+                                    NULL);
+    if (FileMapping == NULL)
+    {
+        Result = GetLastError();
+        goto Cleanup;
+    }
+ 
+    /* Map the file into memory */
+    Address = (LPBYTE)MapViewOfFile(FileMapping, FILE_MAP_READ, 0, 0, 0);
+    if (Address == NULL)
+    {
+        Result = GetLastError();
+        goto Cleanup;
+    }
+ 
+    /* Copy the entire file to the DOS memory */
+    Driver.w.l = 0;
+	Driver.w.h = seg;
+	DriverHeader = (device_t*)FAR_POINTER(Driver);
+	memcpy(DriverHeader, Address, FileSize);
+ 
+    /* Loop through all the drivers in this file */
+    while (TRUE)
+    {
+        if (!(DriverHeader->attributes & DOS_DEVATTR_CHARACTER))
+        {
+            fprintf(stderr, "Error loading driver at %04X:%04X: "
+                    "Block device drivers are not supported.\n",
+                    Driver.w.h,
+                    Driver.w.l);
+            goto Next;
+        }
+ 
+        /* Send the driver an init request */
+        memset(&Request, 0, sizeof(Request));
+        Request.Header.RequestLength = sizeof(DOS_INIT_REQUEST);
+        Request.Header.CommandCode = DOS_DEVCMD_INIT;
+        DosCallDriver(Driver, &Request.Header);
+		
+        if (Request.Header.Status & DOS_DEVSTAT_ERROR)
+        {
+            fprintf(stderr, "Error loading driver at %04X:%04X: "
+                    "Initialization routine returned error %u.\n",
+                    Driver.w.h,
+                    Driver.w.l,
+                    Request.Header.Status & 0x7F);
+            goto Next;
+        }
+
+		//fprintf(stderr, "Adding driver %.*s at %04X:%04X\n", MAX_DEVICE_NAME, DriverHeader->dev_name, Driver.w.h, Driver.w.l);
+        DosAddDriver(Driver);
+        DriversLoaded++;
+ 
+Next:
+        if (DriverHeader->next_driver.w.l == 0xFFFF) break;
+        Driver = DriverHeader->next_driver;
+        DriverHeader = (device_t*)FAR_POINTER(Driver);
+    }
+ 
+Cleanup:
+    if (Result != ERROR_SUCCESS)
+    {
+        /* It was not successful, cleanup the DOS memory */
+        if (seg) msdos_mem_free(seg, false);
+    }
+ 
+    /* Unmap the file */
+    if (Address != NULL) UnmapViewOfFile(Address);
+ 
+    /* Close the file mapping object */
+    if (FileMapping != NULL) CloseHandle(FileMapping);
+ 
+    /* Close the file handle */
+    if (FileHandle != INVALID_HANDLE_VALUE) CloseHandle(FileHandle);
+ 
+    return Result;
+}
+
+// From ReactOS
+static inline WORD DosDriverGenericRequest(PAIR32 Driver, BYTE CommandCode)
+{
+DOS_REQUEST_HEADER Request;
+
+Request.RequestLength = sizeof(DOS_REQUEST_HEADER);
+Request.CommandCode = CommandCode;
+
+DosCallDriver(Driver, &Request);
+
+return Request.Status;
+}
+
+// From ReactOS
+static VOID DosAddDriver(PAIR32 Driver)
+{
+	dos_info_t *dos_info = (dos_info_t *)(mem + DOS_INFO_TOP);
+    device_t *LastDriver = (device_t *)&dos_info->nul_device;
+ 
+    /* Find the last driver in the list */
+    while (LastDriver->next_driver.w.l != 0xFFFF)
+    {
+        LastDriver = (device_t *)FAR_POINTER(LastDriver->next_driver);
+    }
+ 
+    /* Add the new driver to the list */
+    LastDriver->next_driver = Driver;
+    LastDriver = (device_t *)FAR_POINTER(Driver);
+ 
+    if (LastDriver->attributes & 0x0008)	// DOS_DEVATTR_CLOCK
+    {
+        /* Update the active CLOCK driver */
+        dos_info->clock_device = Driver;
+    }
+ 
+    if (LastDriver->attributes
+        & (0x0001 | 0x0002 | 0x0010))	// DOS_DEVATTR_STDIN | DOS_DEVATTR_STDOUT | DOS_DEVATTR_CON
+    {
+        /* Update the active CON driver */
+        dos_info->con_device = Driver;
+    }
+	
+}
+
+// From ReactOS
+static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request)
+{
+    device_t *DriverBlock = (device_t*)FAR_POINTER(Driver);
+	sda_t *sda = (sda_t *)(mem + SDA_TOP);
+
+    UINT16 tmp_AX = CPU_AX;
+    UINT16 tmp_CX = CPU_CX;
+    UINT16 tmp_DX = CPU_DX;
+    UINT16 tmp_BX = CPU_BX;
+    UINT16 tmp_BP = CPU_BP;
+    UINT16 tmp_SI = CPU_SI;
+    UINT16 tmp_DI = CPU_DI;
+    UINT16 tmp_DS = CPU_DS;
+    UINT16 tmp_ES = CPU_ES;
+
+    // Copy the request structure to ES:BX 
+    memmove(&sda->Request, Request, Request->RequestLength);
+ 
+	// Set ES:BX to the location of the request 
+	CPU_LOAD_SREG(CPU_ES_INDEX, SDA_TOP >> 4);
+	CPU_BX = offsetof(sda_t, Request);
+
+    // Call the strategy routine, and then the interrupt routine
+    RunCallback16(Driver.w.h, DriverBlock->strategy);
+    RunCallback16(Driver.w.h, DriverBlock->interrupt);
+ 
+    // Get the request structure from ES:BX
+    memmove(Request, &sda->Request, Request->RequestLength);
+ 
+    // Restore the registers
+    CPU_AX = tmp_AX;
+    CPU_CX = tmp_CX;
+    CPU_DX = tmp_DX;
+    CPU_BX = tmp_BX;
+    CPU_BP = tmp_BP;
+    CPU_SI = tmp_SI;
+    CPU_DI = tmp_DI;
+    CPU_LOAD_SREG(CPU_DS_INDEX, tmp_DS);
+    CPU_LOAD_SREG(CPU_ES_INDEX, tmp_ES);
+
+}
+
+void RunCallback16(UINT16 segment, UINT16 offset)
+{
+	UINT16 tmp_cs = CPU_CS;
+	UINT32 tmp_eip = CPU_EIP;
+
+	CPU_CALL_FAR(segment, offset);
+	// run cpu until routine is done
+	while(!msdos_exit && !(tmp_cs == CPU_CS && tmp_eip == CPU_EIP)) {
+		try {
+			hardware_run_cpu();
+		} catch(...) {
+		}
+	}
+}
+
+PAIR32 dos_get_device(const char* name)
+{
+	dos_info_t *dos_info = (dos_info_t *)(mem + DOS_INFO_TOP);
+	PAIR32 Driver = dos_info->nul_device.next_driver;
+	device_t *DriverHeader;
+
+	if(strlen(name) <= MAX_DEVICE_NAME){
+		// Search in the device_t linked list
+		while (Driver.w.l != 0xFFFF)
+		{
+			DriverHeader = (device_t*)FAR_POINTER(Driver);
+			// Compare both strings and consider ' ' as string termination
+			for(int i = 0; i < MAX_DEVICE_NAME; i++){
+				if((i != 0) && (name[i] == '\0' || name[i] == ' ') && (DriverHeader->dev_name[i] == '\0' || DriverHeader->dev_name[i] == ' ')){
+					return(Driver);
+				}
+				if((name[i] != DriverHeader->dev_name[i]) || name[i] == '\0' || DriverHeader->dev_name[i] == '\0'){
+					break;
+				}
+			}
+			Driver = DriverHeader->next_driver;
+		}
+	}
+	Driver.dw = 0;
+	return(Driver);
+}

--- a/msdos.h
+++ b/msdos.h
@@ -1044,20 +1044,20 @@ typedef struct {
 	UINT8 int21h_5d0ah_called;	// -1
 	// ----- from DOSBox -----
 	UINT8 crit_error_flag;		// 0x00 Critical Error Flag
-	UINT8 indos_flag;			// 0x01 InDOS flag (count of active INT 21 calls)
+	UINT8 indos_flag;		// 0x01 InDOS flag (count of active INT 21 calls)
 	UINT8 drive_crit_error;		// 0x02 Drive on which current critical error occurred or FFh
 	UINT8 locus_of_last_error;	// 0x03 locus of last error
 	UINT16 extended_error_code;	// 0x04 extended error code of last error
 	UINT8 suggested_action;		// 0x06 suggested action for last error
-	UINT8 error_class;			// 0x07 class of last error
+	UINT8 error_class;		// 0x07 class of last error
 	PAIR32 last_error_pointer; 	// 0x08 ES:DI pointer for last error
-	PAIR32 current_dta;			// 0x0C current DTA (Disk Transfer Address)
+	PAIR32 current_dta;		// 0x0C current DTA (Disk Transfer Address)
 	UINT16 current_psp; 		// 0x10 current PSP
-	UINT16 sp_int_23;			// 0x12 stores SP across an INT 23
-	UINT16 return_code;			// 0x14 return code from last process termination (zerod after reading with AH=4Dh)
+	UINT16 sp_int_23;		// 0x12 stores SP across an INT 23
+	UINT16 return_code;		// 0x14 return code from last process termination (zerod after reading with AH=4Dh)
 	UINT8 current_drive;		// 0x16 current drive
 	UINT8 extended_break_flag; 	// 0x17 extended break flag
-	UINT8 fill[2];				// 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort
+	UINT8 fill[2];			// 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort
 	UINT8 unimplemented[24];	// 0x20 not implemented yet (padding)
 	DOS_RW_REQUEST Request;		// 0x38 device driver request header
 } sda_t;

--- a/msdos.h
+++ b/msdos.h
@@ -613,8 +613,6 @@ UINT8 vga_ctrl = 0x01;
 #define DOS_DEVCMD_REMOVABLE    15
 #define DOS_DEVCMD_OUTPUT_BUSY  16
 
-#define DOS_DEVSTAT_DONE    (1 << 8)
-#define DOS_DEVSTAT_BUSY    (1 << 9)
 #define DOS_DEVSTAT_ERROR	(1 << 15)
 
 #define FAR_POINTER(_addr) (mem + ((_addr).w.h << 4) + (_addr).w.l)
@@ -627,7 +625,7 @@ typedef struct _DOS_REQUEST_HEADER
     BYTE CommandCode;
     WORD Status;
     BYTE Reserved[8];
-} DOS_REQUEST_HEADER, *PDOS_REQUEST_HEADER;
+} DOS_REQUEST_HEADER;
 #pragma pack()
  
 #pragma pack(1)
@@ -636,16 +634,8 @@ typedef struct _DOS_INIT_REQUEST
     DOS_REQUEST_HEADER Header;
     BYTE  UnitsInitialized;
     DWORD ReturnBreakAddress;
-    union
-    {
-        DWORD DeviceString; // for character devices
-        struct // for block devices
-        {
-            BYTE FirstDriveLetter;
-            DWORD BpbPointer;
-        };
-    };
-} DOS_INIT_REQUEST, *PDOS_INIT_REQUEST;
+    DWORD DeviceString;
+} DOS_INIT_REQUEST;
 #pragma pack()
 
 #pragma pack(1)
@@ -657,14 +647,14 @@ typedef struct _DOS_RW_REQUEST
     WORD  Length;
     WORD  StartingBlock;
     PAIR32 VolumeLabelPtr;
-} DOS_RW_REQUEST, *PDOS_RW_REQUEST;
+} DOS_RW_REQUEST;
 #pragma pack()
 
-int load_config_sys();
+void load_devices(char *device_list);
 DWORD DosLoadDriver(LPCSTR DriverFile);
 static inline WORD DosDriverRequest(PAIR32 Driver, PAIR32 Buffer, PWORD Length, BYTE CommandCode);
 static VOID DosAddDriver(PAIR32 Driver);
-static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request);
+static VOID DosCallDriver(PAIR32 Driver, DOS_REQUEST_HEADER *Request);
 void RunCallback16(UINT16 segment, UINT16 offset);
 PAIR32 dos_get_device(const char* name);
 

--- a/msdos.h
+++ b/msdos.h
@@ -1035,7 +1035,7 @@ typedef struct {
 	// swappable data area
 	UINT8 printer_cho_flag;		// -34
 	UINT16 int21h_5d0ah_dx;		// -33
-	UINT8 switchar;				// -31 current switch character
+	UINT8 switchar;			// -31 current switch character
 	UINT8 malloc_strategy;		// -30 current memory allocation strategy
 	UINT8 int21h_5d0ah_cl;		// -29
 	UINT8 int21h_5e01h_counter;	// -28

--- a/msdos.h
+++ b/msdos.h
@@ -613,19 +613,24 @@ UINT8 vga_ctrl = 0x01;
 #define DOS_DEVCMD_REMOVABLE    15
 #define DOS_DEVCMD_OUTPUT_BUSY  16
 
-#define DOS_DEVSTAT_ERROR (1 << 15)
+#define DOS_DEVSTAT_DONE    (1 << 8)
+#define DOS_DEVSTAT_BUSY    (1 << 9)
+#define DOS_DEVSTAT_ERROR	(1 << 15)
 
 #define FAR_POINTER(_addr) (mem + ((_addr).w.h << 4) + (_addr).w.l)
 
+#pragma pack(1)
 typedef struct _DOS_REQUEST_HEADER
 {
     BYTE RequestLength;
-    BYTE UnitNumber OPTIONAL;
+    BYTE UnitNumber;
     BYTE CommandCode;
     WORD Status;
     BYTE Reserved[8];
 } DOS_REQUEST_HEADER, *PDOS_REQUEST_HEADER;
+#pragma pack()
  
+#pragma pack(1)
 typedef struct _DOS_INIT_REQUEST
 {
     DOS_REQUEST_HEADER Header;
@@ -641,20 +646,23 @@ typedef struct _DOS_INIT_REQUEST
         };
     };
 } DOS_INIT_REQUEST, *PDOS_INIT_REQUEST;
+#pragma pack()
 
+#pragma pack(1)
 typedef struct _DOS_RW_REQUEST
 {
     DOS_REQUEST_HEADER Header;
-    BYTE  MediaDescriptorByte OPTIONAL;
-    DWORD BufferPointer;
+    BYTE  MediaDescriptorByte;
+    PAIR32 BufferPointer;
     WORD  Length;
-    WORD  StartingBlock  OPTIONAL;
-    DWORD VolumeLabelPtr OPTIONAL;
+    WORD  StartingBlock;
+    PAIR32 VolumeLabelPtr;
 } DOS_RW_REQUEST, *PDOS_RW_REQUEST;
+#pragma pack()
 
 int load_config_sys();
 DWORD DosLoadDriver(LPCSTR DriverFile);
-static inline WORD DosDriverGenericRequest(PAIR32 Driver, BYTE CommandCode);
+static inline WORD DosDriverRequest(PAIR32 Driver, PAIR32 Buffer, PWORD Length, BYTE CommandCode);
 static VOID DosAddDriver(PAIR32 Driver);
 static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request);
 void RunCallback16(UINT16 segment, UINT16 offset);
@@ -1035,7 +1043,7 @@ typedef struct {
 	// swappable data area
 	UINT8 printer_cho_flag;		// -34
 	UINT16 int21h_5d0ah_dx;		// -33
-	UINT8 switchar;			// -31 current switch character
+	UINT8 switchar;				// -31 current switch character
 	UINT8 malloc_strategy;		// -30 current memory allocation strategy
 	UINT8 int21h_5d0ah_cl;		// -29
 	UINT8 int21h_5e01h_counter;	// -28
@@ -1044,20 +1052,20 @@ typedef struct {
 	UINT8 int21h_5d0ah_called;	// -1
 	// ----- from DOSBox -----
 	UINT8 crit_error_flag;		// 0x00 Critical Error Flag
-	UINT8 indos_flag;		// 0x01 InDOS flag (count of active INT 21 calls)
+	UINT8 indos_flag;			// 0x01 InDOS flag (count of active INT 21 calls)
 	UINT8 drive_crit_error;		// 0x02 Drive on which current critical error occurred or FFh
 	UINT8 locus_of_last_error;	// 0x03 locus of last error
 	UINT16 extended_error_code;	// 0x04 extended error code of last error
 	UINT8 suggested_action;		// 0x06 suggested action for last error
-	UINT8 error_class;		// 0x07 class of last error
+	UINT8 error_class;			// 0x07 class of last error
 	PAIR32 last_error_pointer; 	// 0x08 ES:DI pointer for last error
-	PAIR32 current_dta;		// 0x0C current DTA (Disk Transfer Address)
+	PAIR32 current_dta;			// 0x0C current DTA (Disk Transfer Address)
 	UINT16 current_psp; 		// 0x10 current PSP
-	UINT16 sp_int_23;		// 0x12 stores SP across an INT 23
-	UINT16 return_code;		// 0x14 return code from last process termination (zerod after reading with AH=4Dh)
+	UINT16 sp_int_23;			// 0x12 stores SP across an INT 23
+	UINT16 return_code;			// 0x14 return code from last process termination (zerod after reading with AH=4Dh)
 	UINT8 current_drive;		// 0x16 current drive
 	UINT8 extended_break_flag; 	// 0x17 extended break flag
-	UINT8 fill[2];			// 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort
+	UINT8 fill[2];				// 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort
 	UINT8 unimplemented[24];	// 0x20 not implemented yet (padding)
 	DOS_RW_REQUEST Request;		// 0x38 device driver request header
 } sda_t;

--- a/msdos.h
+++ b/msdos.h
@@ -580,6 +580,85 @@ UINT8 vga_gfx_addr = 0;
 UINT8 vga_gfx_regs[16] = {0};
 UINT8 vga_ctrl = 0x01;
 
+/* ----------------------------------------------------------------------------
+	Device Drivers from ReactOS
+---------------------------------------------------------------------------- */
+#define MAX_DEVICE_NAME 8
+
+#define DOS_DEVATTR_STDIN       (1 << 0)
+#define DOS_DEVATTR_STDOUT      (1 << 1)
+#define DOS_DEVATTR_NUL         (1 << 2)
+#define DOS_DEVATTR_CLOCK       (1 << 3)
+#define DOS_DEVATTR_CON         (1 << 4)
+#define DOS_DEVATTR_OPENCLOSE   (1 << 11)
+#define DOS_DEVATTR_SPECIAL     (1 << 13)
+#define DOS_DEVATTR_IOCTL       (1 << 14)
+#define DOS_DEVATTR_CHARACTER   (1 << 15)
+
+#define DOS_DEVCMD_INIT         0
+#define DOS_DEVCMD_MEDIACHK     1
+#define DOS_DEVCMD_BUILDBPB     2
+#define DOS_DEVCMD_IOCTL_READ   3
+#define DOS_DEVCMD_READ         4
+#define DOS_DEVCMD_PEEK         5
+#define DOS_DEVCMD_INSTAT       6
+#define DOS_DEVCMD_FLUSH_INPUT  7
+#define DOS_DEVCMD_WRITE        8
+#define DOS_DEVCMD_WRITE_VERIFY 9
+#define DOS_DEVCMD_OUTSTAT      10
+#define DOS_DEVCMD_FLUSH_OUTPUT 11
+#define DOS_DEVCMD_IOCTL_WRITE  12
+#define DOS_DEVCMD_OPEN         13
+#define DOS_DEVCMD_CLOSE        14
+#define DOS_DEVCMD_REMOVABLE    15
+#define DOS_DEVCMD_OUTPUT_BUSY  16
+
+#define DOS_DEVSTAT_ERROR (1 << 15)
+
+#define FAR_POINTER(_addr) (mem + ((_addr).w.h << 4) + (_addr).w.l)
+
+typedef struct _DOS_REQUEST_HEADER
+{
+    BYTE RequestLength;
+    BYTE UnitNumber OPTIONAL;
+    BYTE CommandCode;
+    WORD Status;
+    BYTE Reserved[8];
+} DOS_REQUEST_HEADER, *PDOS_REQUEST_HEADER;
+ 
+typedef struct _DOS_INIT_REQUEST
+{
+    DOS_REQUEST_HEADER Header;
+    BYTE  UnitsInitialized;
+    DWORD ReturnBreakAddress;
+    union
+    {
+        DWORD DeviceString; // for character devices
+        struct // for block devices
+        {
+            BYTE FirstDriveLetter;
+            DWORD BpbPointer;
+        };
+    };
+} DOS_INIT_REQUEST, *PDOS_INIT_REQUEST;
+
+typedef struct _DOS_RW_REQUEST
+{
+    DOS_REQUEST_HEADER Header;
+    BYTE  MediaDescriptorByte OPTIONAL;
+    DWORD BufferPointer;
+    WORD  Length;
+    WORD  StartingBlock  OPTIONAL;
+    DWORD VolumeLabelPtr OPTIONAL;
+} DOS_RW_REQUEST, *PDOS_RW_REQUEST;
+
+int load_config_sys();
+DWORD DosLoadDriver(LPCSTR DriverFile);
+static inline WORD DosDriverGenericRequest(PAIR32 Driver, BYTE CommandCode);
+static VOID DosAddDriver(PAIR32 Driver);
+static VOID DosCallDriver(PAIR32 Driver, PDOS_REQUEST_HEADER Request);
+void RunCallback16(UINT16 segment, UINT16 offset);
+PAIR32 dos_get_device(const char* name);
 
 /* ----------------------------------------------------------------------------
 	MS-DOS virtual machine
@@ -956,7 +1035,7 @@ typedef struct {
 	// swappable data area
 	UINT8 printer_cho_flag;		// -34
 	UINT16 int21h_5d0ah_dx;		// -33
-	UINT8 switchar;			// -31 current switch character
+	UINT8 switchar;				// -31 current switch character
 	UINT8 malloc_strategy;		// -30 current memory allocation strategy
 	UINT8 int21h_5d0ah_cl;		// -29
 	UINT8 int21h_5e01h_counter;	// -28
@@ -965,20 +1044,22 @@ typedef struct {
 	UINT8 int21h_5d0ah_called;	// -1
 	// ----- from DOSBox -----
 	UINT8 crit_error_flag;		// 0x00 Critical Error Flag
-	UINT8 indos_flag;		// 0x01 InDOS flag (count of active INT 21 calls)
+	UINT8 indos_flag;			// 0x01 InDOS flag (count of active INT 21 calls)
 	UINT8 drive_crit_error;		// 0x02 Drive on which current critical error occurred or FFh
 	UINT8 locus_of_last_error;	// 0x03 locus of last error
 	UINT16 extended_error_code;	// 0x04 extended error code of last error
 	UINT8 suggested_action;		// 0x06 suggested action for last error
-	UINT8 error_class;		// 0x07 class of last error
+	UINT8 error_class;			// 0x07 class of last error
 	PAIR32 last_error_pointer; 	// 0x08 ES:DI pointer for last error
-	PAIR32 current_dta;		// 0x0C current DTA (Disk Transfer Address)
+	PAIR32 current_dta;			// 0x0C current DTA (Disk Transfer Address)
 	UINT16 current_psp; 		// 0x10 current PSP
-	UINT16 sp_int_23;		// 0x12 stores SP across an INT 23
-	UINT16 return_code;		// 0x14 return code from last process termination (zerod after reading with AH=4Dh)
+	UINT16 sp_int_23;			// 0x12 stores SP across an INT 23
+	UINT16 return_code;			// 0x14 return code from last process termination (zerod after reading with AH=4Dh)
 	UINT8 current_drive;		// 0x16 current drive
 	UINT8 extended_break_flag; 	// 0x17 extended break flag
-	UINT8 fill[2];			// 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort
+	UINT8 fill[2];				// 0x18 flag: code page switching || flag: copy of previous byte in case of INT 24 Abort
+	UINT8 unimplemented[24];	// 0x20 not implemented yet (padding)
+	DOS_RW_REQUEST Request;		// 0x38 device driver request header
 } sda_t;
 #pragma pack()
 

--- a/readme.txt
+++ b/readme.txt
@@ -44,8 +44,8 @@ In this case, "COMMAND.COM /C vz.bat readme.doc" will be executed.
 Usage:
 
 MSDOS [-b] [-c[(new exec file)] [-p[P]]] [-d] [-e] [-fN] [-i] [-m] [-n[L[,C]]]
-      [-s[P1[,P2[,P3[,P4]]]]] [-sd] [-sc] [-vX.XX] [-wX.XX] [-x] [-a] [-l] [-h]
-      (command) [options]
+      [-s[P1[,P2[,P3[,P4]]]]] [-sd] [-sc] [-vX.XX] [-wX.XX] [-x] [-a]
+      [-ld[(drivers)]] [-l] [-vt] [-g] [-h] (command) [options]
 
 	-b	stay busy during keyboard polling
 	-c	convert command file to 32bit or 64bit execution file
@@ -63,7 +63,10 @@ MSDOS [-b] [-c[(new exec file)] [-p[P]]] [-d] [-e] [-fN] [-i] [-m] [-n[L[,C]]]
 	-w	set the Windows version
 	-x	enable XMS and LIM EMS
 	-a	disable ANSI.SYS
+	-ld	load device drivers
 	-l	draw box lines with ank characters
+	-vt	toggle vt mode, default is on for win10 and above
+	-g	use cp437 glyphs for code points 0-31, always enabled in cp437
 	-h	allow making cursor invisible
 
 ISH.COM contains any invalid instructions and it cause an error.
@@ -128,6 +131,13 @@ RTS pin of the host's COM port is always active.
 
 NOTE: The maximum baud rate is limited to 9600bps.
 
+To load device drivers, please specify the option '-ld'.
+This is intended for VDD drivers that use NTVDM.
+Drivers made for real DOS may not all work as expected.
+Only character devices from .sys files are supported at the moment.
+You can load multiple drivers by using a ';' delimiter.
+
+	> msdos -ld"device1.sys;device2.sys" command.com
 
 ----- Environment Variable Table
 


### PR DESCRIPTION
I added support for device drivers to be loaded automatically.
This is intended for virtual device drivers that use NTVDM to access the real hardware.
It was already possible to load drivers using software like loadsys or devload.
This new code tries to load every .sys file specified in config.sys before running the dos executable.
Config.sys must be in the same folder as msdos.exe.
Most of this code is from or inspired by ReactOS