### PR TITLE
Fix issue #28

### DIFF
--- a/msdos.cpp
+++ b/msdos.cpp
@@ -4688,6 +4688,9 @@ bool update_console_input()
 									scn += 0x78 - 0x02;	// 1 to 0 - =
 								}
 								chr = 0;
+								enter_key_buf_lock();
+								pcbios_set_key_buffer(0x00, 0x00);
+								leave_key_buf_lock();
 							} else if(ir[i].Event.KeyEvent.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) {
 								if(scn == 0x0e) {
 									chr = 0x7f;	// Ctrl + Back


### PR DESCRIPTION
Patch to fix [Issue# 28](https://github.com/cracyc/msdos-player/issues/28)
Send an extra blank character in the buffer before the actual character when combination of ALT + another key.