### PR TITLE
Fix conflict between 087a7a9 and 34bc066

### DIFF
--- a/msdos.cpp
+++ b/msdos.cpp
@@ -4704,9 +4704,6 @@ bool update_console_input()
 									scn += 0x78 - 0x02;	// 1 to 0 - =
 								}
 								chr = 0x00;
-								enter_key_buf_lock();
-								pcbios_set_key_buffer(0x00, 0x00);
-								leave_key_buf_lock();
 							} else if(ir[i].Event.KeyEvent.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) {
 								if(scn == 0x0e) {
 									chr = 0x7f;	// Ctrl + Back

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -208,7 +208,7 @@ inline char *my_strupr(char *str)
 #else
 #define my_strchr(str, chr) strchr((str), (chr))
 #define my_strrchr(str, chr) strrchr((str), (chr))
-#defube my_strstr(str, search) strstr((str), (search))
+#define my_strstr(str, search) strstr((str), (search))
 #define my_strtok(tok, del) strtok((tok), (del))
 #define my_strtok_s(tok, del, context) strtok_s((tok), (del), (context))
 #define my_strupr(str) _strupr((str))


### PR DESCRIPTION
Pull request https://github.com/cracyc/msdos-player/pull/29 added pcbios_set_key_buffer(0x00, 0x00); on line 4692:
https://github.com/cracyc/msdos-player/commit/087a7a9edfbe865f56d39ce4ae088e58c13c5329#diff-d87583be0959c2640137ef89d96f187428916052656066e568ba20a0a04b6040R4692

Upstream placed it on line 4657 instead:
https://github.com/cracyc/msdos-player/commit/34bc066ee2f479d3cdd5ff1fc83f6c81a0f9de9e#diff-d87583be0959c2640137ef89d96f187428916052656066e568ba20a0a04b6040R4657

So we are doing it twice and it doesn't work.

Removing the one from my initial pull request and leaving the one from upstream.