### PR TITLE
Fix windows 11 non-vt screen width

### DIFF
--- a/msdos.cpp
+++ b/msdos.cpp
@@ -1038,9 +1038,9 @@ void MyWriteConsoleOutputCharAttrA(HANDLE hConsoleOutput, LPCSTR lpCharacter, LP
 				dwWriteCoord.Y++;
 				nLength -= scr_width - dwWriteCoord.X;
 				pos += scr_width - dwWriteCoord.X;
+				dwWriteCoord.X = 0;
 			}
 			while(nLength > scr_width) {
-				dwWriteCoord.X = 0;
 				WriteConsoleOutputCharacterA(hConsoleOutput, lpCharacter + pos, scr_width, dwWriteCoord, &written);
 				WriteConsoleOutputAttribute(hConsoleOutput, attributes + pos, scr_width, dwWriteCoord, &written);
 				dwWriteCoord.Y++;

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -1027,7 +1027,32 @@ void MyWriteConsoleOutputCharAttrA(HANDLE hConsoleOutput, LPCSTR lpCharacter, LP
 		WriteConsoleOutputCharacterW(hConsoleOutput, wchar, nLength, dwWriteCoord, &written);
 		HeapFree(GetProcessHeap(), 0, wchar);
 	} else {
-		WriteConsoleOutputCharacterA(hConsoleOutput, lpCharacter, nLength, dwWriteCoord, &written);
+		if((nLength + dwWriteCoord.X) <= scr_width) {	// No overflow, write everything at once
+			WriteConsoleOutputCharacterA(hConsoleOutput, lpCharacter, nLength, dwWriteCoord, &written);
+			WriteConsoleOutputAttribute(hConsoleOutput, attributes, nLength, dwWriteCoord, &written);
+		} else {	// Manage write coord one line at a time
+			DWORD pos = 0;
+			if(dwWriteCoord.X > 0) {
+				WriteConsoleOutputCharacterA(hConsoleOutput, lpCharacter, scr_width - dwWriteCoord.X, dwWriteCoord, &written);
+				WriteConsoleOutputAttribute(hConsoleOutput, attributes, scr_width - dwWriteCoord.X, dwWriteCoord, &written);
+				dwWriteCoord.Y++;
+				nLength -= scr_width - dwWriteCoord.X;
+				pos += scr_width - dwWriteCoord.X;
+			}
+			while(nLength > scr_width) {
+				dwWriteCoord.X = 0;
+				WriteConsoleOutputCharacterA(hConsoleOutput, lpCharacter + pos, scr_width, dwWriteCoord, &written);
+				WriteConsoleOutputAttribute(hConsoleOutput, attributes + pos, scr_width, dwWriteCoord, &written);
+				dwWriteCoord.Y++;
+				nLength -= scr_width;
+				pos += scr_width;
+			}
+			if(nLength) {
+				WriteConsoleOutputCharacterA(hConsoleOutput, lpCharacter + pos, nLength, dwWriteCoord, &written);
+				WriteConsoleOutputAttribute(hConsoleOutput, attributes + pos, nLength, dwWriteCoord, &written);
+			}				
+		}
+		return;
 	}		
 	if(attributes) {
 		WriteConsoleOutputAttribute(hConsoleOutput, attributes, nLength, dwWriteCoord, &written);


### PR DESCRIPTION
On windows 11 when not using -vt, the screen would overflow as described in issue #16 if the terminal is not resized manually to fit the expected buffer width.
Now -n works even if the window is bigger than 80 columns, with vt disabled.