### PR TITLE
Fix several real-mode DOS program compatibility issues

### DIFF
--- a/mame/emu/cpu/i386/i386.c
+++ b/mame/emu/cpu/i386/i386.c
@@ -2895,8 +2895,12 @@ static void I386OP(decode_opcode)()
 	m_opcode = FETCH();
 
 	if(m_lock && !m_lock_table[0][m_opcode]) {
+#ifdef TOLERATE_BOGUS_LOCK_PREFIX
+		m_lock = false;
+#else
 		I386OP(invalid)();
 		return;
+#endif
 	}
 
 	if( m_operand_size )
@@ -2911,8 +2915,12 @@ static void I386OP(decode_two_byte)()
 	m_opcode = FETCH();
 
 	if(m_lock && !m_lock_table[1][m_opcode]) {
+#ifdef TOLERATE_BOGUS_LOCK_PREFIX
+		m_lock = false;
+#else
 		I386OP(invalid)();
 		return;
+#endif
 	}
 
 	if( m_operand_size )

--- a/mame/emu/cpu/i386/i386priv.h
+++ b/mame/emu/cpu/i386/i386priv.h
@@ -13,12 +13,9 @@
 
 //#define DEBUG_MISSING_OPCODE
 
-/* A LOCK prefix on a non-lockable opcode is #UD on real hardware, but several
-   real-mode DOS programs (e.g. the Word for Word file-conversion modules, which
-   contain "LOCK CMP") carry such redundant prefixes and rely on them simply
-   being ignored, as other DOS emulators do. Drop the stray prefix and execute
-   the instruction normally instead of faulting. Comment out for strict,
-   hardware-accurate behavior. */
+/* Ignore a stray LOCK prefix on a non-lockable opcode instead of raising #UD,
+   as other DOS emulators do; some real-mode programs (e.g. the "LOCK CMP" in
+   the Word for Word converters) rely on it. Comment out for strict behavior. */
 #define TOLERATE_BOGUS_LOCK_PREFIX
 
 #define I386OP(XX)      i386_##XX

--- a/mame/emu/cpu/i386/i386priv.h
+++ b/mame/emu/cpu/i386/i386priv.h
@@ -13,6 +13,14 @@
 
 //#define DEBUG_MISSING_OPCODE
 
+/* A LOCK prefix on a non-lockable opcode is #UD on real hardware, but several
+   real-mode DOS programs (e.g. the Word for Word file-conversion modules, which
+   contain "LOCK CMP") carry such redundant prefixes and rely on them simply
+   being ignored, as other DOS emulators do. Drop the stray prefix and execute
+   the instruction normally instead of faulting. Comment out for strict,
+   hardware-accurate behavior. */
+#define TOLERATE_BOGUS_LOCK_PREFIX
+
 #define I386OP(XX)      i386_##XX
 #define I486OP(XX)      i486_##XX
 #define PENTIUMOP(XX)   pentium_##XX

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -23648,7 +23648,11 @@ int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 	
 	// system file table
 	*(UINT32 *)(mem + SFT_TOP + 0) = 0xffffffff;
-	*(UINT16 *)(mem + SFT_TOP + 4) = 20;
+	// report the configured handle count (-fN, default 20) as the FILES= value
+	// programs read from the SFT block header; it was hardcoded to 20, so apps
+	// that require more (e.g. WordPerfect 5.1 needs FILES>=25) failed even when
+	// -f was raised
+	*(UINT16 *)(mem + SFT_TOP + 4) = max_files;
 	
 	// disk buffer header (from DOSBox)
 	*(UINT16 *)(mem + DISK_BUF_TOP +  0) = 0xffff;		// forward ptr

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -2079,12 +2079,8 @@ void write_byte(UINT32 byteaddress, UINT8 data)
 			char attr = (byteaddress & 1) ? data : mem[byteaddress + 1];
 			write_text_vram((byteaddress & ~1) - text_vram_top_address, chr, attr);
 		} else if(byteaddress >= shadow_buffer_top_address && byteaddress < shadow_buffer_end_address) {
-			// Mirror shadow-buffer (INT 10h FE/FF, TopView/DESQview) writes to the
-			// console whenever the program is using the buffer, not only before
-			// its first INT 10h/FF. WordPerfect writes some updates (e.g. the
-			// F5/F7 status-line prompts) straight to the buffer without a
-			// following FF and relies on it being live; the old !ffh latch left
-			// those writes invisible.
+			// keep mirroring shadow-buffer (INT 10h FE/FF) writes live, not only
+			// before the first FF: WordPerfect writes some updates with no FF
 			if(int_10h_feh_called) {
 				char chr = (byteaddress & 1) ? mem[byteaddress - 1] : data;
 				char attr = (byteaddress & 1) ? data : mem[byteaddress + 1];
@@ -5760,11 +5756,8 @@ process_t *msdos_process_info_create(UINT16 psp_seg, const char *path)
 			process[i].parent_int_10h_ffh_called = int_10h_ffh_called;
 			process[i].parent_ds = CPU_DS;
 			process[i].parent_es = CPU_ES;
-			// Save the parent's callee-saved registers so they can be restored
-			// when the child terminates. Real DOS preserves the caller's BP/SI/DI
-			// across INT 21h/4Bh (EXEC); leaving them holding the child's values
-			// crashes parents (e.g. Word for Word) whose post-EXEC epilogue does
-			// "mov sp,bp / pop bp / retf".
+			// save the parent's callee-saved registers to restore on child exit;
+			// real DOS preserves BP/SI/DI across INT 21h/4Bh (EXEC)
 			process[i].parent_bp = CPU_BP;
 			process[i].parent_si = CPU_SI;
 			process[i].parent_di = CPU_DI;
@@ -10089,10 +10082,8 @@ void msdos_process_terminate(int psp_seg, int ret, int mem_free)
 	CPU_LOAD_SREG(CPU_SS_INDEX, psp->stack.w.h);
 	CPU_SP = psp->stack.w.l;
 	CPU_JMP_FAR(psp->int_22h.w.h, psp->int_22h.w.l);
-	// A parent resuming after its child terminates (the INT 21h/4Bh EXEC path)
-	// must see the carry flag clear to indicate the EXEC succeeded. It resumes
-	// here via INT 22h rather than returning through the INT 21h dispatcher, so
-	// the flag still holds the child's leftover state.
+	// a parent resuming from EXEC must see carry clear (success); it resumes via
+	// INT 22h, not the INT 21h dispatcher, so the flag still holds child state
 	CPU_SET_C_FLAG(0);
 	
 //	process_t *current_process = msdos_process_info_get(psp_seg);
@@ -23648,10 +23639,8 @@ int msdos_init(int argc, char *argv[], char *envp[], int standard_env)
 	
 	// system file table
 	*(UINT32 *)(mem + SFT_TOP + 0) = 0xffffffff;
-	// report the configured handle count (-fN, default 20) as the FILES= value
-	// programs read from the SFT block header; it was hardcoded to 20, so apps
-	// that require more (e.g. WordPerfect 5.1 needs FILES>=25) failed even when
-	// -f was raised
+	// report the configured handle count (-fN, default 20) as FILES=; was
+	// hardcoded to 20, so apps needing more (e.g. WordPerfect 5.1) failed
 	*(UINT16 *)(mem + SFT_TOP + 4) = max_files;
 	
 	// disk buffer header (from DOSBox)

--- a/msdos.cpp
+++ b/msdos.cpp
@@ -2079,7 +2079,13 @@ void write_byte(UINT32 byteaddress, UINT8 data)
 			char attr = (byteaddress & 1) ? data : mem[byteaddress + 1];
 			write_text_vram((byteaddress & ~1) - text_vram_top_address, chr, attr);
 		} else if(byteaddress >= shadow_buffer_top_address && byteaddress < shadow_buffer_end_address) {
-			if(int_10h_feh_called && !int_10h_ffh_called) {
+			// Mirror shadow-buffer (INT 10h FE/FF, TopView/DESQview) writes to the
+			// console whenever the program is using the buffer, not only before
+			// its first INT 10h/FF. WordPerfect writes some updates (e.g. the
+			// F5/F7 status-line prompts) straight to the buffer without a
+			// following FF and relies on it being live; the old !ffh latch left
+			// those writes invisible.
+			if(int_10h_feh_called) {
 				char chr = (byteaddress & 1) ? mem[byteaddress - 1] : data;
 				char attr = (byteaddress & 1) ? data : mem[byteaddress + 1];
 				write_text_vram((byteaddress & ~1) - shadow_buffer_top_address, chr, attr);
@@ -2122,7 +2128,8 @@ void write_word(UINT32 byteaddress, UINT16 data)
 			}
 			write_text_vram(byteaddress - text_vram_top_address, data & 0xff, data >> 8);
 		} else if(byteaddress >= shadow_buffer_top_address && byteaddress < shadow_buffer_end_address) {
-			if(int_10h_feh_called && !int_10h_ffh_called) {
+			// see note in write_byte(): keep mirroring shadow-buffer writes live
+			if(int_10h_feh_called) {
 				write_text_vram(byteaddress - shadow_buffer_top_address, data & 0xff, data >> 8);
 			}
 		}
@@ -5753,6 +5760,14 @@ process_t *msdos_process_info_create(UINT16 psp_seg, const char *path)
 			process[i].parent_int_10h_ffh_called = int_10h_ffh_called;
 			process[i].parent_ds = CPU_DS;
 			process[i].parent_es = CPU_ES;
+			// Save the parent's callee-saved registers so they can be restored
+			// when the child terminates. Real DOS preserves the caller's BP/SI/DI
+			// across INT 21h/4Bh (EXEC); leaving them holding the child's values
+			// crashes parents (e.g. Word for Word) whose post-EXEC epilogue does
+			// "mov sp,bp / pop bp / retf".
+			process[i].parent_bp = CPU_BP;
+			process[i].parent_si = CPU_SI;
+			process[i].parent_di = CPU_DI;
 
 			return(&process[i]);
 		}
@@ -10074,6 +10089,11 @@ void msdos_process_terminate(int psp_seg, int ret, int mem_free)
 	CPU_LOAD_SREG(CPU_SS_INDEX, psp->stack.w.h);
 	CPU_SP = psp->stack.w.l;
 	CPU_JMP_FAR(psp->int_22h.w.h, psp->int_22h.w.l);
+	// A parent resuming after its child terminates (the INT 21h/4Bh EXEC path)
+	// must see the carry flag clear to indicate the EXEC succeeded. It resumes
+	// here via INT 22h rather than returning through the INT 21h dispatcher, so
+	// the flag still holds the child's leftover state.
+	CPU_SET_C_FLAG(0);
 	
 //	process_t *current_process = msdos_process_info_get(psp_seg);
 	process_t *current_process = NULL;
@@ -10093,6 +10113,10 @@ void msdos_process_terminate(int psp_seg, int ret, int mem_free)
 	}
 	CPU_LOAD_SREG(CPU_DS_INDEX, current_process->parent_ds);
 	CPU_LOAD_SREG(CPU_ES_INDEX, current_process->parent_es);
+	// restore the parent's callee-saved registers (see msdos_process_info_create)
+	CPU_BP = current_process->parent_bp;
+	CPU_SI = current_process->parent_si;
+	CPU_DI = current_process->parent_di;
 	
 	if(mem_free) {
 		int mcb_seg, umb_linked;

--- a/msdos.h
+++ b/msdos.h
@@ -1189,6 +1189,9 @@ typedef struct {
 	bool parent_int_10h_ffh_called;
 	UINT16 parent_ds;
 	UINT16 parent_es;
+	UINT16 parent_bp;
+	UINT16 parent_si;
+	UINT16 parent_di;
 	struct {
 		UINT16 handle;
 		UINT16 page;


### PR DESCRIPTION
Three independent fixes found while getting Word for Word (DOS) and the WordPerfect Office editor to run:

1. i386: ignore a bogus LOCK prefix on a non-lockable opcode instead of raising #UD. Some DOS programs (e.g. the Word for Word conversion modules, which contain "LOCK CMP") carry redundant prefixes and rely on them being ignored, as other emulators do. Gated behind TOLERATE_BOGUS_LOCK_PREFIX.

2. msdos: preserve the parent's BP/SI/DI and clear the carry flag when a child process terminates (the INT 21h/4Bh EXEC return). Real DOS preserves the caller's registers across EXEC; leaving them as the child's values crashed parents whose post-EXEC epilogue does "mov sp,bp / pop bp / retf", and a stale carry flag made them treat the EXEC as failed.

3. msdos: keep the INT 10h FE/FF (TopView/DESQview) shadow buffer mirrored to the console after the program's first FF. WordPerfect writes some updates (e.g. the F5/F7 status-line prompts) straight to the buffer without a following FF and relies on it being live.